### PR TITLE
Gitignore spec/fixtures/modules/stdlib (Fixes #15)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /spec/fixtures/.tmp
 /spec/fixtures/Puppetfile.lock
 /spec/fixtures/modules/boxen/
+/spec/fixtures/modules/stdlib/
 /spec/fixtures/vendor


### PR DESCRIPTION
I can confirm issue #15 as described by @afeld. Please add
spec/fixtures/modules/stdlib to .gitignore.
