### PR TITLE
Add Note for Adding GITHUB_API_TOKEN to Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ boxen::example { 'best example ever':
 
 ## Development
 
-Set `GITHUB_API_TOKEN` in your shell with a [Github oAuth Token](https://help.github.com/articles/creating-an-oauth-token-for-command-line-use) to raise your API rate limit. You can get some work done without it, but you're less likely to encounter errors like `Unable to find module 'boxen/puppet-boxen' on https://github.com`.
+Set `GITHUB_API_TOKEN` in your shell with a [Github oAuth Token](https://help.github.com/articles/creating-an-oauth-token-for-command-line-use) to raise your API rate limit. You can get some work done without it, but you're less likely to encounter errors like `Unable to find module 'boxen/puppet-boxen' on https://github.com`. You can also set this environment variable securely on Travis to ensure your CI builds don't run into the same issue - check out Travis's [docs on repository settings](http://docs.travis-ci.com/user/environment-variables/).
 
 Then write some code. Run `script/cibuild` to test it. Check the `script`
 directory for other useful tools.


### PR DESCRIPTION
I thought it would be nice to add a note about setting `GITHUB_API_TOKEN` on Travis itself so people don't have to go digging around for that information to get their builds working.

Remember, a building CI is a happy CI!
