### PR TITLE
Travis: Be explicit about the language (make travis-lint happy)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 ---
+language: ruby
 script: "./script/cibuild"
 gemfile: "this/does/not/exist"
 rvm:


### PR DESCRIPTION
I know it's a template and it should probably be as generic as possible, but I still think, that it should rather be explicit. It will make people notice it and change it if they need to change it. Otherwise they might be surprised that it's defaulting to `ruby`.

https://lint.travis-ci.org/boxen/puppet-template
